### PR TITLE
Subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ await eth.end()
 
 For a list of supported methods see https://wiki.parity.io/JSONRPC-eth-module.html
 
+If you are using Parity you can also use the pubsub module, to subscribe to
+changes:
+
+```js
+const unsubscribe = await eth.subscribe(eth.getBlockByNumber('latest', false), function (block) {
+  if (parseInt(block.timestamp) > Date.now() - 1000 * 60) return unsubscribe()
+
+  console.log(block)
+})
+```
+
 ## RPC providers
 
 The following RPC providers are included

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ class Request {
     this.args = args
   }
 
-  then () {
-    return this.rpc.request(this.method, this.args)
+  then (resolve) {
+    return resolve(this.rpc.request(this.method, this.args))
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -20,167 +20,167 @@ module.exports = class ETH {
   }
 
   accounts () {
-    return new Request('eth_accounts', [])
+    return new Request(this.rpc, 'eth_accounts', [])
   }
 
   blockNumber () {
-    return new Request('eth_blockNumber', [])
+    return new Request(this.rpc, 'eth_blockNumber', [])
   }
 
   call (obj, from) {
-    return new Request('eth_call', from ? [obj, from] : [obj])
+    return new Request(this.rpc, 'eth_call', from ? [obj, from] : [obj])
   }
 
   chainId () {
-    return new Request('eth_chainId', [])
+    return new Request(this.rpc, 'eth_chainId', [])
   }
 
   coinbase () {
-    return new Request('eth_coinbase', [])
+    return new Request(this.rpc, 'eth_coinbase', [])
   }
 
   estimateGas (obj, from) {
-    return new Request('eth_estimateGas', from ? [obj, from] : [obj])
+    return new Request(this.rpc, 'eth_estimateGas', from ? [obj, from] : [obj])
   }
 
   gasPrice () {
-    return new Request('eth_gasPrice', [])
+    return new Request(this.rpc, 'eth_gasPrice', [])
   }
 
   getBalance (obj, from) {
-    return new Request('eth_getBalance', from ? [obj, from] : [obj])
+    return new Request(this.rpc, 'eth_getBalance', from ? [obj, from] : [obj])
   }
 
   getBlockByHash (hash, tx) {
-    return new Request('eth_getBlockByHash', [hash, tx || false])
+    return new Request(this.rpc, 'eth_getBlockByHash', [hash, tx || false])
   }
 
   getBlockByNumber (n, tx) {
-    return new Request('eth_getBlockByNumber', [n, tx || false])
+    return new Request(this.rpc, 'eth_getBlockByNumber', [n, tx || false])
   }
 
   getBlockTransactionCountByHash (hash) {
-    return new Request('eth_getBlockTransactionCountByHash', [hash])
+    return new Request(this.rpc, 'eth_getBlockTransactionCountByHash', [hash])
   }
 
   getBlockTransactionCountByNumber (n) {
-    return new Request('eth_getBlockTransactionCountByNumber', [n])
+    return new Request(this.rpc, 'eth_getBlockTransactionCountByNumber', [n])
   }
 
   getCode (addr, from) {
-    return new Request('eth_getCode', from ? [addr, from] : [addr])
+    return new Request(this.rpc, 'eth_getCode', from ? [addr, from] : [addr])
   }
 
   getFilterChanges (id) {
-    return new Request('eth_getFilterChanges', [id])
+    return new Request(this.rpc, 'eth_getFilterChanges', [id])
   }
 
   getFilterLogs (id) {
-    return new Request('eth_getFilterLogs', [id])
+    return new Request(this.rpc, 'eth_getFilterLogs', [id])
   }
 
   getLogs (obj) {
-    return new Request('eth_getLogs', [obj])
+    return new Request(this.rpc, 'eth_getLogs', [obj])
   }
 
   getStorageAt (addr, pos, from) {
-    return new Request('eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
+    return new Request(this.rpc, 'eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
   }
 
   getTransactionByBlockHashAndIndex (hash, pos) {
-    return new Request('eth_getTransactionByBlockHashAndIndex', [hash, pos])
+    return new Request(this.rpc, 'eth_getTransactionByBlockHashAndIndex', [hash, pos])
   }
 
   getTransactionByBlockNumberAndIndex (hash, pos) {
-    return new Request('eth_getTransactionByBlockNumberAndIndex', [hash, pos])
+    return new Request(this.rpc, 'eth_getTransactionByBlockNumberAndIndex', [hash, pos])
   }
 
   getTransactionByHash (hash) {
-    return new Request('eth_getTransactionByHash', [hash])
+    return new Request(this.rpc, 'eth_getTransactionByHash', [hash])
   }
 
   getTransactionCount (addr, from) {
-    return new Request('eth_getTransactionCount', from ? [addr, from] : [addr])
+    return new Request(this.rpc, 'eth_getTransactionCount', from ? [addr, from] : [addr])
   }
 
   getTransactionReceipt (hash) {
-    return new Request('eth_getTransactionReceipt', [hash])
+    return new Request(this.rpc, 'eth_getTransactionReceipt', [hash])
   }
 
   getUncleByBlockHashAndIndex (hash, pos) {
-    return new Request('eth_getUncleByBlockHashAndIndex', [hash, pos])
+    return new Request(this.rpc, 'eth_getUncleByBlockHashAndIndex', [hash, pos])
   }
 
   getUncleByBlockNumberAndIndex (n, pos) {
-    return new Request('eth_getUncleByBlockNumberAndIndex', [n, pos])
+    return new Request(this.rpc, 'eth_getUncleByBlockNumberAndIndex', [n, pos])
   }
 
   getUncleCountByBlockHash (hash) {
-    return new Request('eth_getUncleCountByBlockHash', [hash])
+    return new Request(this.rpc, 'eth_getUncleCountByBlockHash', [hash])
   }
 
   getUncleCountByBlockNumber (hash) {
-    return new Request('eth_getUncleCountByBlockNumber', [hash])
+    return new Request(this.rpc, 'eth_getUncleCountByBlockNumber', [hash])
   }
 
   getWork () {
-    return new Request('eth_getWork', [])
+    return new Request(this.rpc, 'eth_getWork', [])
   }
 
   hashrate () {
-    return new Request('eth_hashrate', [])
+    return new Request(this.rpc, 'eth_hashrate', [])
   }
 
   mining () {
-    return new Request('eth_mining', [])
+    return new Request(this.rpc, 'eth_mining', [])
   }
 
   newBlockFilter () {
-    return new Request('eth_newBlockFilter', [])
+    return new Request(this.rpc, 'eth_newBlockFilter', [])
   }
 
   newFilter (obj) {
-    return new Request('eth_newFilter', [obj])
+    return new Request(this.rpc, 'eth_newFilter', [obj])
   }
 
   newPendingTransactionFilter () {
-    return new Request('eth_newPendingTransactionFilter', [])
+    return new Request(this.rpc, 'eth_newPendingTransactionFilter', [])
   }
 
   protocolVersion () {
-    return new Request('eth_protocolVersion', [])
+    return new Request(this.rpc, 'eth_protocolVersion', [])
   }
 
   sendRawTransaction (data) {
-    return new Request('eth_sendRawTransaction', [data])
+    return new Request(this.rpc, 'eth_sendRawTransaction', [data])
   }
 
   sendTransaction (data) {
-    return new Request('eth_sendTransaction', [data])
+    return new Request(this.rpc, 'eth_sendTransaction', [data])
   }
 
   sign (addr, data) {
-    return new Request('eth_sign', [addr, data])
+    return new Request(this.rpc, 'eth_sign', [addr, data])
   }
 
   signTransaction (obj) {
-    return new Request('eth_signTransaction', [obj])
+    return new Request(this.rpc, 'eth_signTransaction', [obj])
   }
 
   submitHashrate (a, b) {
-    return new Request('eth_submitHashrate', [a, b])
+    return new Request(this.rpc, 'eth_submitHashrate', [a, b])
   }
 
   submitWork (a, b, c) {
-    return new Request('eth_submitWork', [a, b, c])
+    return new Request(this.rpc, 'eth_submitWork', [a, b, c])
   }
 
   syncing () {
-    return new Request('eth_syncing', [])
+    return new Request(this.rpc, 'eth_syncing', [])
   }
 
   uninstallFilter () {
-    return new Request('eth_uninstallFilter', [])
+    return new Request(this.rpc, 'eth_uninstallFilter', [])
   }
 
   end () {

--- a/index.js
+++ b/index.js
@@ -1,170 +1,185 @@
 module.exports = class ETH {
   constructor (rpc) {
     this.rpc = rpc
+
+    this.Request = class Request {
+      constructor (method, args = []) {
+        this.method = method
+        this.args = args
+      }
+
+      then () {
+        return rpc.request(this.method, this.args)
+      }
+    }
+  }
+
+  subscribe (req, cb) {
+    return this.rpc.subscribe(req.method, req.args, cb)
   }
 
   accounts () {
-    return this.rpc.request('eth_accounts', [])
+    return new this.Request('eth_accounts', [])
   }
 
   blockNumber () {
-    return this.rpc.request('eth_blockNumber', [])
+    return new this.Request('eth_blockNumber', [])
   }
 
   call (obj, from) {
-    return this.rpc.request('eth_call', from ? [obj, from] : [obj])
+    return new this.Request('eth_call', from ? [obj, from] : [obj])
   }
 
   chainId () {
-    return this.rpc.request('eth_chainId', [])
+    return new this.Request('eth_chainId', [])
   }
 
   coinbase () {
-    return this.rpc.request('eth_coinbase', [])
+    return new this.Request('eth_coinbase', [])
   }
 
   estimateGas (obj, from) {
-    return this.rpc.request('eth_estimateGas', from ? [obj, from] : [obj])
+    return new this.Request('eth_estimateGas', from ? [obj, from] : [obj])
   }
 
   gasPrice () {
-    return this.rpc.request('eth_gasPrice', [])
+    return new this.Request('eth_gasPrice', [])
   }
 
   getBalance (obj, from) {
-    return this.rpc.request('eth_getBalance', from ? [obj, from] : [obj])
+    return new this.Request('eth_getBalance', from ? [obj, from] : [obj])
   }
 
   getBlockByHash (hash, tx) {
-    return this.rpc.request('eth_getBlockByHash', [hash, tx || false])
+    return new this.Request('eth_getBlockByHash', [hash, tx || false])
   }
 
   getBlockByNumber (n, tx) {
-    return this.rpc.request('eth_getBlockByNumber', [n, tx || false])
+    return new this.Request('eth_getBlockByNumber', [n, tx || false])
   }
 
   getBlockTransactionCountByHash (hash) {
-    return this.rpc.request('eth_getBlockTransactionCountByHash', [hash])
+    return new this.Request('eth_getBlockTransactionCountByHash', [hash])
   }
 
   getBlockTransactionCountByNumber (n) {
-    return this.rpc.request('eth_getBlockTransactionCountByNumber', [n])
+    return new this.Request('eth_getBlockTransactionCountByNumber', [n])
   }
 
   getCode (addr, from) {
-    return this.rpc.request('eth_getCode', from ? [addr, from] : [addr])
+    return new this.Request('eth_getCode', from ? [addr, from] : [addr])
   }
 
   getFilterChanges (id) {
-    return this.rpc.request('eth_getFilterChanges', [id])
+    return new this.Request('eth_getFilterChanges', [id])
   }
 
   getFilterLogs (id) {
-    return this.rpc.request('eth_getFilterLogs', [id])
+    return new this.Request('eth_getFilterLogs', [id])
   }
 
   getLogs (obj) {
-    return this.rpc.request('eth_getLogs', [obj])
+    return new this.Request('eth_getLogs', [obj])
   }
 
   getStorageAt (addr, pos, from) {
-    return this.rpc.request('eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
+    return new this.Request('eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
   }
 
   getTransactionByBlockHashAndIndex (hash, pos) {
-    return this.rpc.request('eth_getTransactionByBlockHashAndIndex', [hash, pos])
+    return new this.Request('eth_getTransactionByBlockHashAndIndex', [hash, pos])
   }
 
   getTransactionByBlockNumberAndIndex (hash, pos) {
-    return this.rpc.request('eth_getTransactionByBlockNumberAndIndex', [hash, pos])
+    return new this.Request('eth_getTransactionByBlockNumberAndIndex', [hash, pos])
   }
 
   getTransactionByHash (hash) {
-    return this.rpc.request('eth_getTransactionByHash', [hash])
+    return new this.Request('eth_getTransactionByHash', [hash])
   }
 
   getTransactionCount (addr, from) {
-    return this.rpc.request('eth_getTransactionCount', from ? [addr, from] : [addr])
+    return new this.Request('eth_getTransactionCount', from ? [addr, from] : [addr])
   }
 
   getTransactionReceipt (hash) {
-    return this.rpc.request('eth_getTransactionReceipt', [hash])
+    return new this.Request('eth_getTransactionReceipt', [hash])
   }
 
   getUncleByBlockHashAndIndex (hash, pos) {
-    return this.rpc.request('eth_getUncleByBlockHashAndIndex', [hash, pos])
+    return new this.Request('eth_getUncleByBlockHashAndIndex', [hash, pos])
   }
 
   getUncleByBlockNumberAndIndex (n, pos) {
-    return this.rpc.request('eth_getUncleByBlockNumberAndIndex', [n, pos])
+    return new this.Request('eth_getUncleByBlockNumberAndIndex', [n, pos])
   }
 
   getUncleCountByBlockHash (hash) {
-    return this.rpc.request('eth_getUncleCountByBlockHash', [hash])
+    return new this.Request('eth_getUncleCountByBlockHash', [hash])
   }
 
   getUncleCountByBlockNumber (hash) {
-    return this.rpc.request('eth_getUncleCountByBlockNumber', [hash])
+    return new this.Request('eth_getUncleCountByBlockNumber', [hash])
   }
 
   getWork () {
-    return this.rpc.request('eth_getWork', [])
+    return new this.Request('eth_getWork', [])
   }
 
   hashrate () {
-    return this.rpc.request('eth_hashrate', [])
+    return new this.Request('eth_hashrate', [])
   }
 
   mining () {
-    return this.rpc.request('eth_mining', [])
+    return new this.Request('eth_mining', [])
   }
 
   newBlockFilter () {
-    return this.rpc.request('eth_newBlockFilter', [])
+    return new this.Request('eth_newBlockFilter', [])
   }
 
   newFilter (obj) {
-    return this.rpc.request('eth_newFilter', [obj])
+    return new this.Request('eth_newFilter', [obj])
   }
 
   newPendingTransactionFilter () {
-    return this.rpc.request('eth_newPendingTransactionFilter', [])
+    return new this.Request('eth_newPendingTransactionFilter', [])
   }
 
   protocolVersion () {
-    return this.rpc.request('eth_protocolVersion', [])
+    return new this.Request('eth_protocolVersion', [])
   }
 
   sendRawTransaction (data) {
-    return this.rpc.request('eth_sendRawTransaction', [data])
+    return new this.Request('eth_sendRawTransaction', [data])
   }
 
   sendTransaction (data) {
-    return this.rpc.request('eth_sendTransaction', [data])
+    return new this.Request('eth_sendTransaction', [data])
   }
 
   sign (addr, data) {
-    return this.rpc.request('eth_sign', [addr, data])
+    return new this.Request('eth_sign', [addr, data])
   }
 
   signTransaction (obj) {
-    return this.rpc.request('eth_signTransaction', [obj])
+    return new this.Request('eth_signTransaction', [obj])
   }
 
   submitHashrate (a, b) {
-    return this.rpc.request('eth_submitHashrate', [a, b])
+    return new this.Request('eth_submitHashrate', [a, b])
   }
 
   submitWork (a, b, c) {
-    return this.rpc.request('eth_submitWork', [a, b, c])
+    return new this.Request('eth_submitWork', [a, b, c])
   }
 
   syncing () {
-    return this.rpc.request('eth_syncing', [])
+    return new this.Request('eth_syncing', [])
   }
 
   uninstallFilter () {
-    return this.rpc.request('eth_uninstallFilter', [])
+    return new this.Request('eth_uninstallFilter', [])
   }
 
   end () {

--- a/index.js
+++ b/index.js
@@ -1,185 +1,186 @@
+class Request {
+  constructor (rpc, method, args = []) {
+    this.rpc = rpc
+    this.method = method
+    this.args = args
+  }
+
+  then () {
+    return this.rpc.request(this.method, this.args)
+  }
+}
+
 module.exports = class ETH {
   constructor (rpc) {
     this.rpc = rpc
-
-    this.Request = class Request {
-      constructor (method, args = []) {
-        this.method = method
-        this.args = args
-      }
-
-      then () {
-        return rpc.request(this.method, this.args)
-      }
-    }
   }
 
   subscribe (req, cb) {
-    return this.rpc.subscribe(req.method, req.args, cb)
+    return req.rpc.subscribe(req.method, req.args, cb)
   }
 
   accounts () {
-    return new this.Request('eth_accounts', [])
+    return new Request('eth_accounts', [])
   }
 
   blockNumber () {
-    return new this.Request('eth_blockNumber', [])
+    return new Request('eth_blockNumber', [])
   }
 
   call (obj, from) {
-    return new this.Request('eth_call', from ? [obj, from] : [obj])
+    return new Request('eth_call', from ? [obj, from] : [obj])
   }
 
   chainId () {
-    return new this.Request('eth_chainId', [])
+    return new Request('eth_chainId', [])
   }
 
   coinbase () {
-    return new this.Request('eth_coinbase', [])
+    return new Request('eth_coinbase', [])
   }
 
   estimateGas (obj, from) {
-    return new this.Request('eth_estimateGas', from ? [obj, from] : [obj])
+    return new Request('eth_estimateGas', from ? [obj, from] : [obj])
   }
 
   gasPrice () {
-    return new this.Request('eth_gasPrice', [])
+    return new Request('eth_gasPrice', [])
   }
 
   getBalance (obj, from) {
-    return new this.Request('eth_getBalance', from ? [obj, from] : [obj])
+    return new Request('eth_getBalance', from ? [obj, from] : [obj])
   }
 
   getBlockByHash (hash, tx) {
-    return new this.Request('eth_getBlockByHash', [hash, tx || false])
+    return new Request('eth_getBlockByHash', [hash, tx || false])
   }
 
   getBlockByNumber (n, tx) {
-    return new this.Request('eth_getBlockByNumber', [n, tx || false])
+    return new Request('eth_getBlockByNumber', [n, tx || false])
   }
 
   getBlockTransactionCountByHash (hash) {
-    return new this.Request('eth_getBlockTransactionCountByHash', [hash])
+    return new Request('eth_getBlockTransactionCountByHash', [hash])
   }
 
   getBlockTransactionCountByNumber (n) {
-    return new this.Request('eth_getBlockTransactionCountByNumber', [n])
+    return new Request('eth_getBlockTransactionCountByNumber', [n])
   }
 
   getCode (addr, from) {
-    return new this.Request('eth_getCode', from ? [addr, from] : [addr])
+    return new Request('eth_getCode', from ? [addr, from] : [addr])
   }
 
   getFilterChanges (id) {
-    return new this.Request('eth_getFilterChanges', [id])
+    return new Request('eth_getFilterChanges', [id])
   }
 
   getFilterLogs (id) {
-    return new this.Request('eth_getFilterLogs', [id])
+    return new Request('eth_getFilterLogs', [id])
   }
 
   getLogs (obj) {
-    return new this.Request('eth_getLogs', [obj])
+    return new Request('eth_getLogs', [obj])
   }
 
   getStorageAt (addr, pos, from) {
-    return new this.Request('eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
+    return new Request('eth_getStorageAt', from ? [addr, pos, from] : [addr, pos])
   }
 
   getTransactionByBlockHashAndIndex (hash, pos) {
-    return new this.Request('eth_getTransactionByBlockHashAndIndex', [hash, pos])
+    return new Request('eth_getTransactionByBlockHashAndIndex', [hash, pos])
   }
 
   getTransactionByBlockNumberAndIndex (hash, pos) {
-    return new this.Request('eth_getTransactionByBlockNumberAndIndex', [hash, pos])
+    return new Request('eth_getTransactionByBlockNumberAndIndex', [hash, pos])
   }
 
   getTransactionByHash (hash) {
-    return new this.Request('eth_getTransactionByHash', [hash])
+    return new Request('eth_getTransactionByHash', [hash])
   }
 
   getTransactionCount (addr, from) {
-    return new this.Request('eth_getTransactionCount', from ? [addr, from] : [addr])
+    return new Request('eth_getTransactionCount', from ? [addr, from] : [addr])
   }
 
   getTransactionReceipt (hash) {
-    return new this.Request('eth_getTransactionReceipt', [hash])
+    return new Request('eth_getTransactionReceipt', [hash])
   }
 
   getUncleByBlockHashAndIndex (hash, pos) {
-    return new this.Request('eth_getUncleByBlockHashAndIndex', [hash, pos])
+    return new Request('eth_getUncleByBlockHashAndIndex', [hash, pos])
   }
 
   getUncleByBlockNumberAndIndex (n, pos) {
-    return new this.Request('eth_getUncleByBlockNumberAndIndex', [n, pos])
+    return new Request('eth_getUncleByBlockNumberAndIndex', [n, pos])
   }
 
   getUncleCountByBlockHash (hash) {
-    return new this.Request('eth_getUncleCountByBlockHash', [hash])
+    return new Request('eth_getUncleCountByBlockHash', [hash])
   }
 
   getUncleCountByBlockNumber (hash) {
-    return new this.Request('eth_getUncleCountByBlockNumber', [hash])
+    return new Request('eth_getUncleCountByBlockNumber', [hash])
   }
 
   getWork () {
-    return new this.Request('eth_getWork', [])
+    return new Request('eth_getWork', [])
   }
 
   hashrate () {
-    return new this.Request('eth_hashrate', [])
+    return new Request('eth_hashrate', [])
   }
 
   mining () {
-    return new this.Request('eth_mining', [])
+    return new Request('eth_mining', [])
   }
 
   newBlockFilter () {
-    return new this.Request('eth_newBlockFilter', [])
+    return new Request('eth_newBlockFilter', [])
   }
 
   newFilter (obj) {
-    return new this.Request('eth_newFilter', [obj])
+    return new Request('eth_newFilter', [obj])
   }
 
   newPendingTransactionFilter () {
-    return new this.Request('eth_newPendingTransactionFilter', [])
+    return new Request('eth_newPendingTransactionFilter', [])
   }
 
   protocolVersion () {
-    return new this.Request('eth_protocolVersion', [])
+    return new Request('eth_protocolVersion', [])
   }
 
   sendRawTransaction (data) {
-    return new this.Request('eth_sendRawTransaction', [data])
+    return new Request('eth_sendRawTransaction', [data])
   }
 
   sendTransaction (data) {
-    return new this.Request('eth_sendTransaction', [data])
+    return new Request('eth_sendTransaction', [data])
   }
 
   sign (addr, data) {
-    return new this.Request('eth_sign', [addr, data])
+    return new Request('eth_sign', [addr, data])
   }
 
   signTransaction (obj) {
-    return new this.Request('eth_signTransaction', [obj])
+    return new Request('eth_signTransaction', [obj])
   }
 
   submitHashrate (a, b) {
-    return new this.Request('eth_submitHashrate', [a, b])
+    return new Request('eth_submitHashrate', [a, b])
   }
 
   submitWork (a, b, c) {
-    return new this.Request('eth_submitWork', [a, b, c])
+    return new Request('eth_submitWork', [a, b, c])
   }
 
   syncing () {
-    return new this.Request('eth_syncing', [])
+    return new Request('eth_syncing', [])
   }
 
   uninstallFilter () {
-    return new this.Request('eth_uninstallFilter', [])
+    return new Request('eth_uninstallFilter', [])
   }
 
   end () {

--- a/metamask.js
+++ b/metamask.js
@@ -31,5 +31,9 @@ class RPC {
     })
   }
 
+  subscribe () {
+    throw new Error('Metamask does not support pubsub')
+  }
+
   destroy () {}
 }


### PR DESCRIPTION
This is an initial pass on using `parity_pubsub`, which allows you to listen for changes on other APIs. You need to add `--ipc-apis=parity_pubsub` as an exposed API.

Here's an example that listens on updates to the block height:

```js
  const eth = new Nanoeth(path.resolve(__dirname, `./parity.sock`))
  const unsubscribe = await eth.rpc.subscribe('eth_blockNumber', function (height) {
    console.log(parseInt(height))
  })
```

You can await the subscription so you can subscribe before eg. fetching initial state, but be sure you listener is live. The function returns a function to unsubscribe.

How we expose this beyond the call onto `eth.rpc` I'm not sure yet. Subscriptions should be bound to the connection, so closing it like we do now should cancel all subscriptions from parity, but we perhaps need to do cleanup here?